### PR TITLE
dmpt.question pk 15 obligatory null makes loaddata operation break

### DIFF
--- a/devfixtures.json
+++ b/devfixtures.json
@@ -370,7 +370,7 @@
     "help_text": "",
     "framing_text": "",
     "comment": "",
-    "obligatory": null,
+    "obligatory": false,
     "node": null
   }
 },


### PR DESCRIPTION
Trying to load devfixtures.json breaks if the dmpt.question pk:15 obligatory value is null