### PR TITLE
Add a maintenance mode middleware

### DIFF
--- a/src/easydmp/lib/middleware.py
+++ b/src/easydmp/lib/middleware.py
@@ -1,0 +1,15 @@
+from django.conf import settings
+from django.shortcuts import render
+from django.utils.cache import add_never_cache_headers
+from django.utils.deprecation import MiddlewareMixin
+
+
+class MaintenanceModeMiddleware(MiddlewareMixin):
+
+    def process_request(self, request):
+        if not getattr(settings, 'MAINTENANCE_MODE', None):
+            return None
+
+        response = render(request, '503.html', content_type='text/html', status=503)
+        add_never_cache_headers(response)
+        return response

--- a/src/easydmp/site/settings/base.py
+++ b/src/easydmp/site/settings/base.py
@@ -69,6 +69,7 @@ SITE_ID = 1 # For flatpages
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'easydmp.lib.middleware.MaintenanceModeMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/src/easydmp/site/templates/503.html
+++ b/src/easydmp/site/templates/503.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>EasyDMP: 500 Server Error</title>
+</head>
+<body>
+  <h1>503 Service Unavailable</h1>
+
+  <p>EasyDMP is currently down for maintenance. Try stopping by in an hour.</p>
+
+</body>
+</html>


### PR DESCRIPTION
If `MAINTENANCE_MODE = True` is in settings, answers all site visits regardless of url with "503 service unavailable". Otherwise it's a noop.