### PR TITLE
Add support for toggleable pagination

### DIFF
--- a/src/easydmp/lib/api/pagination.py
+++ b/src/easydmp/lib/api/pagination.py
@@ -1,0 +1,25 @@
+from rest_framework import pagination
+
+
+__all__ = [
+    'PageNumberPagination',
+    'ToggleablePageNumberPagination',
+]
+
+
+class PageNumberPagination(pagination.PageNumberPagination):
+    page_size_query_param = 'page_size'
+
+
+class ToggleablePageNumberPagination(PageNumberPagination):
+    "Paginate if `page_size` is an integer in GET query paramaters"
+
+    def paginate_queryset(self, queryset, request, view=None):
+        page_size = 0
+        try:
+            page_size = int(request.query_params.get(self.page_size_query_param, 0))
+        except TypeError:
+            pass
+        if page_size:  # Reuse page_size to enable pagination
+            return super().paginate_queryset(queryset, request, view)
+        return None

--- a/src/easydmp/plan/api/views.py
+++ b/src/easydmp/plan/api/views.py
@@ -10,6 +10,7 @@ from django_filters.rest_framework.filterset import FilterSet
 
 from easydmp.auth.api.views import UserSerializer
 
+from easydmp.lib.api.pagination import ToggleablePageNumberPagination
 from easydmp.plan.models import Plan
 from easydmp.plan.models import SectionValidity
 from easydmp.plan.models import QuestionValidity
@@ -154,6 +155,7 @@ class PlanViewSet(ReadOnlyModelViewSet):
     filter_class = PlanFilter
     search_fields = ['=id', 'title', '=abbreviation']
     serializer_class = HeavyPlanSerializer
+    pagination_class = ToggleablePageNumberPagination
 
 # 
 #     def get_serializer_class(self):


### PR DESCRIPTION
Closes #124 and #118.

On the plan list API endpoint, if the query parameter `page_size` is set to an integer, paging will be turned on with that page size. Otherwise it's a standard DRF PageNumberPagination.

