### PR TITLE
Type hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *~
 .coverage*
 .tox
+.mypi.ini
 localsettings.py
 Attic
 htmlcov
@@ -15,6 +16,7 @@ dist
 staticfiles
 _build
 eudat-template
+mypi.ini
 collected_static_files
 src/easydmp/dmpt/static/**/*.svg
 src/easydmp/dmpt/static/**/*.png

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,3 +50,14 @@ exclude =
     templates,
     src/flow,
     src/easydmp/theme
+
+[mypy]
+ignore_missing_imports = True
+
+[mypy-*/migrations/*]
+# Auto-generated
+ignore_errors = True
+
+[mypy-*/settings/*]
+# Settings are a mess, cause by being python, not text
+ignore_errors = True

--- a/src/easydmp/dmpt/admin.py
+++ b/src/easydmp/dmpt/admin.py
@@ -120,16 +120,16 @@ class TemplateAdmin(SetPermissionsMixin, ObjectPermissionModelAdmin):
         if obj.published:
             return True
         return False
-    is_published.short_description = 'Is published'
-    is_published.boolean = True
+    is_published.short_description = 'Is published'  # type: ignore
+    is_published.boolean = True  # type: ignore
 
 
     def is_retired(self, obj):
         if obj.retired:
             return True
         return False
-    is_retired.short_description = 'Is retired'
-    is_retired.boolean = True
+    is_retired.short_description = 'Is retired'  # type: ignore
+    is_retired.boolean = True  # type: ignore
 
 
     # actions
@@ -137,12 +137,12 @@ class TemplateAdmin(SetPermissionsMixin, ObjectPermissionModelAdmin):
     def new_version(self, request, queryset):
         for q in queryset.all():
             q.new_version()
-    new_version.short_description = 'Create new version'
+    new_version.short_description = 'Create new version'  # type: ignore
 
     def private_copy(self, request, queryset):
         for q in queryset.all():
             q.private_copy()
-    private_copy.short_description = 'Make a private copy'
+    private_copy.short_description = 'Make a private copy'  # type: ignore
 
 
 @admin.register(Section)
@@ -197,8 +197,8 @@ class SectionAdmin(ObjectPermissionModelAdmin):
         pdf_url = reverse('v1:section-graph', kwargs={'pk': obj.pk})
         html = '<a target="_blank" href="{}">PDF</a>'
         return format_html(html, mark_safe(pdf_url))
-    graph_pdf.short_description = 'Graph'
-    graph_pdf.allow_tags = True
+    graph_pdf.short_description = 'Graph'  # type: ignore
+    graph_pdf.allow_tags = True  # type: ignore
 
     # actions
 
@@ -206,7 +206,7 @@ class SectionAdmin(ObjectPermissionModelAdmin):
         for q in queryset.order_by('-position'):
             q.position += 1
             q.save()
-    increment_position.short_description = 'Increment position by 1'
+    increment_position.short_description = 'Increment position by 1'  # type: ignore
 
     def decrement_position(self, request, queryset):
         qs = queryset.order_by('position')
@@ -216,7 +216,7 @@ class SectionAdmin(ObjectPermissionModelAdmin):
             for q in qs:
                 q.position -= 1
                 q.save()
-    decrement_position.short_description = 'Decrement position by 1'
+    decrement_position.short_description = 'Decrement position by 1'  # type: ignore
 
 
 class QuestionExplicitBranchInline(admin.StackedInline):
@@ -388,8 +388,8 @@ class QuestionAdmin(ObjectPermissionModelAdmin):
 
     def get_mount(self, obj):
         return obj.eestore.eestore_type if obj.eestore else ''
-    get_mount.short_description = 'EEStore'
-    get_mount.admin_order_field = 'eestore'
+    get_mount.short_description = 'EEStore'  # type: ignore
+    get_mount.admin_order_field = 'eestore'  # type: ignore
 
     # actions
 
@@ -397,13 +397,13 @@ class QuestionAdmin(ObjectPermissionModelAdmin):
         for q in queryset.all():
             q.on_trunk = not q.on_trunk
             q.save()
-    toggle_on_trunk.short_description = 'Toggle whether on trunk'
+    toggle_on_trunk.short_description = 'Toggle whether on trunk'  # type: ignore
 
     def increment_position(self, request, queryset):
         for q in queryset.order_by('-position'):
             q.position += 1
             q.save()
-    increment_position.short_description = 'Increment position by 1'
+    increment_position.short_description = 'Increment position by 1'  # type: ignore
 
     def decrement_position(self, request, queryset):
         qs = queryset.order_by('position')
@@ -413,7 +413,7 @@ class QuestionAdmin(ObjectPermissionModelAdmin):
             for q in qs:
                 q.position -= 1
                 q.save()
-    decrement_position.short_description = 'Decrement position by 1'
+    decrement_position.short_description = 'Decrement position by 1'  # type: ignore
 
 
 @admin.register(ExplicitBranch)

--- a/src/easydmp/dmpt/flow.py
+++ b/src/easydmp/dmpt/flow.py
@@ -11,7 +11,7 @@ __all__ = [
 LOG_TRACE = 5
 
 LOG = logging.getLogger(__name__)
-LOG.trace = lambda *args, **kwargs: LOG.log(LOG_TRACE, *args, **kwargs)
+LOG.trace = lambda *args, **kwargs: LOG.log(LOG_TRACE, *args, **kwargs)  # type: ignore
 
 
 HashableOrNone = Optional[Hashable]

--- a/src/easydmp/dmpt/forms.py
+++ b/src/easydmp/dmpt/forms.py
@@ -204,11 +204,10 @@ class DateRangeForm(AbstractNodeForm):
             if data and data.lower and data.upper:
                 start, end = data.lower, data.upper
                 return {
-                    'choice':
-                        {
-                            'start': start.isoformat(),
-                            'end': end.isoformat(),
-                        },
+                    'choice': {
+                        'start': start.isoformat(),
+                        'end': end.isoformat(),
+                    },
                 }
             else:
                 if self.question.optional:
@@ -219,7 +218,8 @@ class DateRangeForm(AbstractNodeForm):
 
     def pprint(self):
         if self.is_valid() and not self.question.optional:
-            return '{}–{}'.format(self.serialize())
+            choice = self.serialize()['choice']
+            return '{}–{}'.format(choice['start'], choice['end'])
         return 'Not set'
 
     def serialize_choice(self):

--- a/src/easydmp/dmpt/utils.py
+++ b/src/easydmp/dmpt/utils.py
@@ -83,4 +83,4 @@ class RenumberMixin:
         for i, obj in enumerate(objects, 1):
             obj.position = i
             obj.save()
-    _renumber_positions.alters_data = True
+    _renumber_positions.alters_data = True  # type: ignore

--- a/src/easydmp/eventlog/models.py
+++ b/src/easydmp/eventlog/models.py
@@ -100,11 +100,11 @@ class EventLogQuerySet(models.QuerySet):
 
     def delete(self):
         return (0, {})
-    delete.queryset_only = True
+    delete.queryset_only = True  # type: ignore
 
     def update(self, **_):
         return 0
-    update.queryset_only = True
+    update.queryset_only = True  # type: ignore
 
     def _get_gfks(self, field, *objects):
         ct = GFK_MAPPER[field]['ct']

--- a/src/easydmp/invitation/models.py
+++ b/src/easydmp/invitation/models.py
@@ -33,8 +33,8 @@ class InvitationQuerySet(models.QuerySet):
 
 
 class AbstractEmailInvitation(models.Model):
-    template_name = None
-    email_subject_template = None
+    template_name: str
+    email_subject_template: str
 
     uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     email_address = models.EmailField()

--- a/src/easydmp/invitation/views.py
+++ b/src/easydmp/invitation/views.py
@@ -90,7 +90,7 @@ class CreatePlanViewerInvitationView(AbstractCreatePlanInvitationView):
 
 
 class AbstractPlanInvitationView:
-    fields = []
+#    fields = []
     pk_url_kwarg = 'uuid'
 
     def get_invitations(self):

--- a/src/easydmp/plan/admin.py
+++ b/src/easydmp/plan/admin.py
@@ -43,13 +43,13 @@ class PlanAdmin(admin.ModelAdmin):
         for q in queryset.filter(locked__isnull=True):
             q.lock(request.user)
             self.message_user(request, 'Successfully locked "{}"'.format(str(q)))
-    lock.short_description = 'Lock (set read-only) plans'
+    lock.short_description = 'Lock (set read-only) plans'  # type: ignore
 
     def publish(self, request, queryset):
         for q in queryset.filter(locked__isnull=True, published__isnull=True):
             q.publish(request.user)
             self.message_user(request, 'Successfully published "{}"'.format(str(q)))
-    publish.short_description = 'Publish plans'
+    publish.short_description = 'Publish plans'  # type: ignore
 
 
 @admin.register(PlanComment)


### PR DESCRIPTION
Copied from the commit:

> Add some type hints to tricky bits
> 
> As part of making setions repeatable, a lot of the underlying mechanics
> of moving answers around will change. For that reason, type hints will
> be added *in moderation* where needed, to serve as in-code documentation.
> 
> This does *not* mean that we will aim for everything typed. (To type
> hint, you need to import types that will only be used for annotations,
>  which may lead to cyclical import hell. The simplest way to avoid
>  cyclical imports is to put everything into a single file. That does NOT
>  wash. If a type needs to be imported due to annotations only, hide
>  it behind `if typing.TYPE_CHECKING:`, then they wont interfere at
>  runtime. Also, be generous with the use of
>  `from _future__ import annotations`.)
> 
>  "mypi.ini" and ".mypi.ini" are set to be ignored by git so that the
>  config in "setup.cfg" can be easily overridden locally.