### PR TITLE
Start using `drf-spectacular` for OpenAPI support

### DIFF
--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -16,6 +16,7 @@ djangorestframework-jwt==1.11.0
 django-select2==6.3.1
 dj-database-url==0.5.0
 docutils==0.16
+drf-spectacular==0.9.14
 graphviz==0.13.2
 idna==2.8
 imagesize==1.1.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,3 +17,4 @@ social-auth-app-django>=3.1
 social-auth-core>=3.2.0
 Sphinx>=2.3.1
 whitenoise>=5.0.1
+drf-spectacular>=0.9.14

--- a/src/easydmp/plan/api/views.py
+++ b/src/easydmp/plan/api/views.py
@@ -1,3 +1,6 @@
+from django_filters.rest_framework.filterset import FilterSet
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from rest_framework.decorators import action
 from rest_framework.fields import JSONField
@@ -6,10 +9,7 @@ from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
-from django_filters.rest_framework.filterset import FilterSet
-
 from easydmp.auth.api.views import UserSerializer
-
 from easydmp.lib.api.pagination import ToggleablePageNumberPagination
 from easydmp.plan.models import Plan
 from easydmp.plan.models import SectionValidity
@@ -86,6 +86,7 @@ class LightPlanSerializer(serializers.HyperlinkedModelSerializer):
             'published',
         ]
 
+    @extend_schema_field(OpenApiTypes.URI)
     def get_generated_html_url(self, obj):
         return reverse( 'generated_plan_html', kwargs={'plan': obj.id},
                        request=self.context['request'])
@@ -149,6 +150,7 @@ class HeavyPlanSerializer(LightPlanSerializer):
             'published',
             'published_by',
         ]
+        read_only_fields = ['generated_html']
 
 
 class PlanViewSet(ReadOnlyModelViewSet):

--- a/src/easydmp/site/settings/base.py
+++ b/src/easydmp/site/settings/base.py
@@ -16,6 +16,8 @@ pathjoin = os.path.join
 
 import dj_database_url
 
+from ... import __version__ as VERSION
+
 
 def getenv(name, default=None):
     value = os.getenv(name, default)
@@ -54,6 +56,7 @@ INSTALLED_APPS = [
     'django_filters',
     'guardian',
     'corsheaders',
+    'drf_spectacular',
 
     'easydmp.auth.apps.EasyDMPAuthConfig',
     'easydmp.dmpt',
@@ -266,14 +269,22 @@ REST_FRAMEWORK = {
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.NamespaceVersioning',
     'DEFAULT_VERSION': 'v1',
     'DEFAULT_FILTER_BACKENDS': (
-        'django_filters.rest_framework.backends.DjangoFilterBackend',
+        'drf_spectacular.contrib.django_filters.DjangoFilterBackend',
         'rest_framework.filters.SearchFilter',
     ),
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }
 
 JWT_AUTH = {
     'JWT_ALLOW_REFRESH': True,
     'JWT_LEEWAY': 30,
+}
+
+# drf-spectacular (swagger/OpenAPI)
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'EasyDMP',
+    'VERSION': VERSION,
 }
 
 # PSA

--- a/src/easydmp/site/urls.py
+++ b/src/easydmp/site/urls.py
@@ -16,6 +16,10 @@ Including another URLconf
 from django.conf import settings
 from django.conf.urls import url, include
 from django.contrib import admin
+from django.views.generic.base import RedirectView
+from django.urls import path
+
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 from easydmp.site.views import Homepage
 from easydmp.site.views import LoginView
@@ -40,6 +44,9 @@ urlpatterns = [
 
     url(r'dmpt/', include('easydmp.dmpt.urls')),
 
+    path('api/', RedirectView.as_view(pattern_name='swagger-ui'), name='go-to-swagger-ui'),
+    path('api/schema/',SpectacularAPIView.as_view(), name='schema'),
+    path('api/schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
     url(r'^api/v1/', include('easydmp.site.api.urls', namespace='v1')),
 ]
 


### PR DESCRIPTION
Generate OpenAPI schema on `/api/schema/` and swagger UI on `/api/schema/swagger-ui/`. Rdirects from `/api/` to the latter.