### PR TITLE
Read logging config from separate file

### DIFF
--- a/src/easydmp/site/logging.py
+++ b/src/easydmp/site/logging.py
@@ -1,0 +1,47 @@
+DEFAULT = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse',
+        },
+        'require_debug_true': {
+            '()': 'django.utils.log.RequireDebugTrue',
+        },
+        'select_filter': {
+            '()': 'easydmp.lib.log.SQLFilter',
+            'keywords': ['SELECT'],
+        },
+    },
+    'handlers': {
+        'null': {
+            'class': 'logging.NullHandler',
+        },
+        'mail_admins': {
+            'level': 'ERROR',
+            'class': 'django.utils.log.AdminEmailHandler',
+            'include_html': True,
+        },
+        'console': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        '': {
+            'handlers': ['console', 'mail_admins'],
+            'level': 'INFO',
+        },
+        'easydmp': {
+            'handlers': ['console',],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        'django.db.backends': {
+            'handlers': ['console'],
+            'filters': ['select_filter'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+    },
+}

--- a/src/easydmp/site/settings/__init__.py
+++ b/src/easydmp/site/settings/__init__.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import logging.config
+import os
+
+from django.utils.module_loading import import_string
+
+from easydmp import __version__ as VERSION
+
+__all__ = [
+    'VERSION',
+    'updir',
+    'pathjoin',
+    'getenv',
+    'setup_logging',
+    'update_loglevels',
+]
+updir = os.path.dirname
+pathjoin = os.path.join
+
+
+def getenv(name, default=None):
+    value = os.getenv(name, default)
+    if isinstance(value, str):
+        value = value.strip()
+    return value
+
+
+def setup_logging(dotted_path=None):
+    '''Use the dictionary on the dotted path to set up logging
+
+    Returns the dictionary on success, otherwise None.
+    '''
+    if dotted_path:
+        try:
+            class_or_attr = import_string(dotted_path)
+        except AttributeError:
+            return
+        logging.config.dictConfig(class_or_attr)
+        return class_or_attr
+
+
+def update_loglevels(loglevel: str = 'INFO', loggers=(), handlers=()):
+    '''Override specific loglevels in already setup loggers or handlers'''
+    loglevel = loglevel.upper()
+    for logger in loggers:
+        logging.getLogger(logger).setLevel(loglevel)
+    if handlers:
+        handlerdict = {}
+        for handler in handlers:
+            handlerdict['handler'] = {'level': loglevel}
+        logdict = {
+            'version': 1,
+            'disable_existing_loggers': False,
+            'incremental': True,
+            'handlers': handlerdict,
+        }
+        logging.config.dictConfig(logdict)

--- a/src/easydmp/site/settings/base.py
+++ b/src/easydmp/site/settings/base.py
@@ -11,19 +11,10 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
 import os
-updir = os.path.dirname
-pathjoin = os.path.join
 
 import dj_database_url
 
-from ... import __version__ as VERSION
-
-
-def getenv(name, default=None):
-    value = os.getenv(name, default)
-    if isinstance(value, str):
-        value = value.strip()
-    return value
+from . import VERSION, updir, pathjoin, getenv, setup_logging, update_loglevels
 
 SECRET_KEY = getenv('SECRET_KEY', None)
 
@@ -185,56 +176,13 @@ STATICFILES_DIRS = [
 STATIC_ROOT = pathjoin(BASE_DIR, 'collected_static_files')
 
 # Default logging
-# Init logging by "import logging.config; logging.config.dictConfig(LOGGING)"
-LOGLEVEL = getenv('LOGLEVEL', 'info').upper()
+# Override log levels by ``update-loglevels``
 LOGGING_CONFIG = None
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'filters': {
-        'require_debug_false': {
-            '()': 'django.utils.log.RequireDebugFalse',
-        },
-        'require_debug_true': {
-            '()': 'django.utils.log.RequireDebugTrue',
-        },
-        'select_filter': {
-            '()': 'easydmp.lib.log.SQLFilter',
-            'keywords': ['SELECT'],
-        },
-    },
-    'handlers': {
-        'null': {
-            'class': 'logging.NullHandler',
-        },
-        'mail_admins': {
-            'level': 'ERROR',
-            'class': 'django.utils.log.AdminEmailHandler',
-            'include_html': True,
-        },
-        'console': {
-            'level': LOGLEVEL,
-            'class': 'logging.StreamHandler',
-        },
-    },
-    'loggers': {
-        '': {
-            'handlers': ['console', 'mail_admins'],
-            'level': 'INFO',
-        },
-        'easydmp': {
-            'handlers': ['console',],
-            'level': LOGLEVEL,
-            'propagate': False,
-        },
-        'django.db.backends': {
-            'handlers': ['console'],
-            'filters': ['select_filter'],
-            'level': LOGLEVEL,
-            'propagate': False,
-        },
-    },
-}
+LOGGING_MODULE = getenv('DJANGO_LOGGING_MODULE', None)
+if LOGGING_MODULE:
+    STARTUP_LOGGING = setup_logging(LOGGING_MODULE)
+
+
 SERVER_EMAIL = getenv('SERVER_EMAIL', 'root@localhost')
 
 # Auth

--- a/src/easydmp/site/settings/production.py
+++ b/src/easydmp/site/settings/production.py
@@ -11,6 +11,9 @@ assert SECRET_KEY, 'Env "SECRET_KEY" not set'
 
 assert DATABASES.get('default', None), '"DATABASES" must be set'
 
+if not LOGGING_MODULE:
+    LOGGING = setup_logging('easydmp.site.logging.DEFAULT')
+
 try:
     DEBUG
 except NameError:
@@ -38,10 +41,6 @@ AUTHENTICATION_BACKENDS = [
     'dataporten.social.DataportenEmailOAuth2',
     'b2access.B2AccessOAuth2'
 ] + AUTHENTICATION_BACKENDS
-
-import logging.config
-logging.config.dictConfig(LOGGING)
-
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
 


### PR DESCRIPTION
* Move all settings helper-functions to `easydmp.site.settings`
* Allow easy overriding of loglevels, by the name of a handler or logger
* Include the default production logging in a new module

This incidentally solves a problem on Django 3.1 triggered by running
`logging.config.dictConfig` multiple times or logging something before
logging is set up.