### PR TITLE
Fix bug due to url arg now being int, not str

### DIFF
--- a/src/easydmp/plan/models.py
+++ b/src/easydmp/plan/models.py
@@ -40,6 +40,10 @@ class AnswerHelper():
         self.section_validity = self.get_section_validity()
         self.current_choice = plan.data.get(self.question_id, {})
 
+    def get_initial(self, data):
+        choice = data.get(self.question_id, {})
+        return choice
+
     def get_question_validity(self):
         qv, _ = Answer.objects.get_or_create(
             plan=self.plan,

--- a/src/easydmp/plan/views/__init__.py
+++ b/src/easydmp/plan/views/__init__.py
@@ -439,7 +439,9 @@ class UpdateLinearSectionView(PlanAccessViewMixin, DetailView):
         return kwargs
 
     def get_initial_for_answer(self, answer):
-        choice = self.plan.data.get(str(answer.question_id), {})
+        choice = answer.get_initial(self.plan.data)
+        if not choice:
+            choice = answer.get_initial(self.plan.previous_data)
         return choice
 
     def get_forms(self):
@@ -548,11 +550,9 @@ class NewQuestionView(AbstractQuestionMixin, UpdateView):
         self.referer = request.META.get('HTTP_REFERER', None)
 
     def get_initial(self):
-        current_data = self.object.data or {}
-        previous_data = self.object.previous_data or {}
-        initial = current_data.get(self.question_pk, {})
+        initial = self.answer.get_initial(self.object.data)
         if not initial:
-            initial = previous_data.get(self.question_pk, {})
+            initial = self.answer.get_initial(self.object.previous_data)
         return initial
 
     def get_success_url(self):


### PR DESCRIPTION
The `path()` function can cast to a type, and doesn't send in just
strings. This confused plan.NewQuestionView.get_initial(), which assumed it
would get a string.

Also, plan.NewQuestionView.get_initial() now behaves more like
UpdateLinearSectionView.get_initial_for_answer(), both now using
AnswerHelper.