### PR TITLE
Mark tests that need JSONField support

### DIFF
--- a/tests/plan/models/test_Plan.py
+++ b/tests/plan/models/test_Plan.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 from django import test
+from django.test import tag, skipUnlessDBFeature
 
 from easydmp.auth.models import User
 from easydmp.dmpt.models import Template
@@ -9,6 +10,8 @@ from tests.dmpt.factories import TemplateFactory, SectionFactory
 from tests.plan.factories import PlanFactory
 
 
+@tag('JSONField')
+@skipUnlessDBFeature('has_jsonb_agg')
 class TestPlanValidation(test.TestCase):
 
     def setUp(self):

--- a/tests/plan/test_rda10.py
+++ b/tests/plan/test_rda10.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from django import test
+from django.test import tag, skipUnlessDBFeature
 
 from easydmp.auth.models import User
 from easydmp.dmpt.models import Template
@@ -8,6 +9,8 @@ from easydmp.plan.models import Plan
 from easydmp.plan.utils import GenerateRDA10
 
 
+@tag('JSONField')
+@skipUnlessDBFeature('has_jsonb_agg')
 class RdaTest(test.TestCase):
 
     def test_rda10_export(self):

--- a/tests/plan/test_urls.py
+++ b/tests/plan/test_urls.py
@@ -1,4 +1,5 @@
 from django import test
+from django.test import tag, skipUnlessDBFeature
 from django.urls import reverse
 
 from easydmp.dmpt.models import Section, Question
@@ -40,6 +41,8 @@ def make_kwargs(args):
     return kwargs
 
 
+@tag('JSONField')
+@skipUnlessDBFeature('has_jsonb_agg')
 class AccessTestCase(test.TestCase):
 
     def setUp(self):

--- a/tests/plan/test_views.py
+++ b/tests/plan/test_views.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from django import test
+from django.test import tag, skipUnlessDBFeature
 from django.urls import reverse
 from django.utils.timezone import now as utcnow
 
@@ -9,6 +10,8 @@ from tests.plan.factories import PlanFactory
 from tests.auth.factories import UserFactory
 
 
+@tag('JSONField')
+@skipUnlessDBFeature('has_jsonb_agg')
 class GeneratedViewTestCase(test.TestCase):
 
     def setUp(self):

--- a/tests/test_easydmp_util_stats.py
+++ b/tests/test_easydmp_util_stats.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from django.test import TestCase
+from django.test import TestCase, tag, skipUnlessDBFeature
 from django.utils.timezone import now as tznow
 
 from guardian.utils import get_anonymous_user
@@ -40,6 +40,8 @@ class StatsTestCase(TestCase):
         }
         self.assertDictEqual(result, expected)
 
+    @tag('JSONField')
+    @skipUnlessDBFeature('has_jsonb_agg')
     def test_some_users_and_plans_some_stats(self):
         template = Template.objects.create(title='testtemplate')
         u1 = User.objects.create(username='testuser1', email='a@b.com')


### PR DESCRIPTION
Tag them with "JSONField" so they can be run separately, or excluded
explicitly, see django docs on "Testing tools":
https://docs.djangoproject.com/en/2.2/topics/testing/tools/

Also mark them with `skipUnlessDBFeature('has_jsonb_agg')` so that they
are not run on sqlite.

When switching to Django 3.1 or newer and using the new JSONField there,
"has_jsonb_agg" should be changed to "supports_json_field".