### PR TITLE
Add API authentication by token

### DIFF
--- a/docs/api/logging_in.rst
+++ b/docs/api/logging_in.rst
@@ -1,15 +1,52 @@
-==============================
-Logging in to the API with JWT
-==============================
+===========================
+Authenticating with the API
+===========================
 
-Getting the token
-=================
+To use the non-public API endpoints it is necessary to either be
+logged in (by reusing the session cookie) or utilize a token.
 
-You need to have a separate password to use the non-public bits of the
-API.
+There are two kinds of tokens available: Bearer tokens and JSON
+Web Tokens (JWT).
 
-Getting the password
---------------------
+The former is meant for one-off CLI-work by people, while the
+latter is better suited for automation and software agents.
+
+Authenticating with bearer token
+================================
+
+There is no verification or refreshing of bearer tokens. They work
+until they are deleted.
+
+Get the token
+-------------
+
+Superusers
+..........
+
+Get/create a token via the admin or the management-command
+``drf_create_token``.
+
+Regular users
+.............
+
+Ask a superuser for a token, for instance via asking support for
+your specific instance.
+
+Use the token
+-------------
+
+Add the header ``Authorization: Bearer YOUR_TOKEN`` to all
+requests, where YOUR_TOKEN is the token you got from the previous
+step.
+
+Authenticating with JWT
+=======================
+
+For JWT you need a non-SSO password, because you fetch the token
+by logging in.
+
+Get a password
+--------------
 
 Superusers
 ..........
@@ -22,33 +59,32 @@ Regular users
 
 There is no automated way to set a password for regular users, as who’s
 authorized to get the extra access to the API hasn’t been specified yet.
-One possible way would be applying for API access in the user profile,
-which then would have to be accepted by an administrator.
 
 Currently, ask support for your specific instance to set a password for
 you if you need the access.
 
-.. _getting-the-token-1:
+(One possible way would be applying for API access in the user profile,
+which then would have to be accepted by an administrator.)
 
 Getting the token
 -----------------
 
 When you have a password, get the token at
-``/api/v1/jwt/authenticate/``. The token is what you will need to store
-in your client.
+``/api/v1/jwt/authenticate/``. This token is what you will need to
+store in your client.
 
 Logging in
-==========
+----------
 
 After having the token, log in at ``/api/v1/jwt/authenticate/``.
 Afterwards you should have access to the private API.
 
 Verifying the token
-===================
+-------------------
 
-POST your token into ``api/v1/jwt/verify/``.
+POST the token into ``api/v1/jwt/verify/``.
 
-Refresh your token
-==================
+Refresh the token
+-----------------
 
-POST your token into ``/api/v1/jwt/refresh/``.
+POST the token into ``/api/v1/jwt/refresh/``.

--- a/src/easydmp/auth/admin.py
+++ b/src/easydmp/auth/admin.py
@@ -2,6 +2,8 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.utils.translation import ugettext, ugettext_lazy as _
 
+from rest_framework.authtoken.admin import TokenAdmin
+
 from .models import User
 
 
@@ -17,3 +19,6 @@ class EasyDMPUserAdmin(UserAdmin):
                                        'groups',)}),
         (_('Important dates'), {'fields': ('last_login', 'date_joined')}),
     )
+
+
+TokenAdmin.raw_id_fields = ['user']

--- a/src/easydmp/auth/authentication.py
+++ b/src/easydmp/auth/authentication.py
@@ -1,0 +1,5 @@
+from rest_framework.authentication import TokenAuthentication as DRFTokenAuthentication
+
+
+class TokenAuthentication(DRFTokenAuthentication):
+    keyword = 'Bearer'

--- a/src/easydmp/site/settings/base.py
+++ b/src/easydmp/site/settings/base.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     'guardian',
     'corsheaders',
     'drf_spectacular',
+    'rest_framework.authtoken',
 
     'easydmp.auth.apps.EasyDMPAuthConfig',
     'easydmp.dmpt',
@@ -208,6 +209,7 @@ X_FRAME_OPTIONS = 'ALLOW-FROM https://bibsys.no/'
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
+        'easydmp.auth.authentication.TokenAuthentication',
         'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
     ],


### PR DESCRIPTION
For CLI usage of the API, authenticating with just a token is very
convenient.

The header looks like "Authorization: Bearer GVFHTYt75y68vghbyj"
where the stuff after "Bearer" is a token connected to a single User.

Since this is meant for CLI API usage, no attempts are made to make it
easy to get a token for an ordinary user. Tokens can be made and fetched
via the admin and via a management command and that's it.

This will create a new table in the database.