### PR TITLE
Authenticate via bearer token in Django proper

### DIFF
--- a/src/easydmp/auth/middleware.py
+++ b/src/easydmp/auth/middleware.py
@@ -1,7 +1,12 @@
 from django.conf import settings
+from django.contrib import auth
 from django.contrib.auth.views import redirect_to_login
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.encoding import force_text
+from rest_framework import exceptions as drf_exceptions
+
+from .authentication import TokenAuthentication
 
 
 class LoginRequiredMiddleware(MiddlewareMixin):
@@ -12,14 +17,15 @@ class LoginRequiredMiddleware(MiddlewareMixin):
         self.get_response = get_response
 
     def process_view(self, request, view_func, _view_args, _view_kwargs):
-        assert hasattr(request, 'user'), (
-            "The LoginRequiredMiddleware requires authentication middleware "
-            "to be installed. Edit your MIDDLEWARE%s setting to insert "
-            "'django.contrib.auth.middleware.AuthenticationMiddleware' "
-            "before this middleware." % (
-            "_CLASSES" if settings.MIDDLEWARE is None else ""
+        if not hasattr(request, 'user'):
+            raise ImproperlyConfigured(
+                "The TokenAuthenticationMiddleware requires authentication middleware "
+                "to be installed. Edit your MIDDLEWARE%s setting to insert "
+                "'django.contrib.auth.middleware.AuthenticationMiddleware' "
+                "before this middleware." % (
+                    "_CLASSES" if settings.MIDDLEWARE is None else ""
+                )
             )
-        )
 
         # If CBV has the attribute login_required == False, allow
         view_class = getattr(view_func, 'view_class', None)
@@ -41,3 +47,49 @@ class LoginRequiredMiddleware(MiddlewareMixin):
 
         # Redirect unauthenticated users to login page
         return redirect_to_login(request.get_full_path(), self.login_url, 'next')
+
+
+class TokenAuthenticationMiddleware(MiddlewareMixin):
+
+    def process_request(self, request):
+        if not hasattr(request, 'user'):
+            raise ImproperlyConfigured(
+                "The TokenAuthenticationMiddleware requires authentication middleware "
+                "to be installed. Edit your MIDDLEWARE%s setting to insert "
+                "'django.contrib.auth.middleware.AuthenticationMiddleware' "
+                "before this middleware." % (
+                    "_CLASSES" if settings.MIDDLEWARE is None else ""
+                )
+            )
+
+        user = None
+        try:
+            result = TokenAuthentication().authenticate(request)
+            if result is not None:
+                user, _ = result
+        except drf_exceptions.AuthenticationFailed:
+            return
+
+        if not user or not (user.is_active and user.is_superuser):
+            return
+
+        # If the user is already authenticated and that user is the user we are
+        # getting passed in the headers, then the correct user is already
+        # persisted in the session and we don't need to continue.
+        if request.user.is_authenticated:
+            if request.user == user:
+                return
+            else:
+                # An authenticated user is associated with the request, but
+                # it does not match the authorized user in the header.
+                auth.logout(request)
+
+        # We are seeing this user for the first time in this session, attempt
+        # to authenticate the user.
+        username = user.username
+        user = auth.authenticate(request, remote_user=username)
+        if user:
+            # User is valid.  Set request.user and persist user in the session
+            # by logging the user in.
+            request.user = user
+            auth.login(request, user)

--- a/src/easydmp/site/settings/base.py
+++ b/src/easydmp/site/settings/base.py
@@ -71,6 +71,7 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'easydmp.auth.middleware.LoginRequiredMiddleware',
+    'easydmp.auth.middleware.TokenAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',


### PR DESCRIPTION
This allows authenticating via drf token for any django view. Ugly, still sets session, while the point of token auth is no session. I don't think this is the correct way either but it beats the fugly direct hack on the generated plan views (#180).