### PR TITLE
Fix bug when importing template that uses eestore

### DIFF
--- a/src/easydmp/dmpt/export_template.py
+++ b/src/easydmp/dmpt/export_template.py
@@ -77,7 +77,7 @@ class CannedAnswerExportSerializer(serializers.ModelSerializer):
 
 class EEStoreMountExportSerializer(serializers.ModelSerializer):
     question = serializers.PrimaryKeyRelatedField(
-        many=False, queryset=Question.objects.all()
+        many=False, read_only=True,
     )
     eestore_type = serializers.StringRelatedField(many=False, read_only=True)
     sources = serializers.StringRelatedField(many=True, read_only=True)


### PR DESCRIPTION
There was some unnecessary validation in the ExportSerializer that
prevented import. We need to export the primary keys of EEStoreMounts in
order to map them to the new question ids, but validators are designed
to check what is needed on implicit, automatic create and assumes the
old question ids exist unchanged. We are validating only to check that
the JSON is well-formed, not to directly write the JSON into the
database, so a validator needed to be relaxed.